### PR TITLE
Add list apps installs + list users + minor fix

### DIFF
--- a/SimpleMDMpy/Apps.py
+++ b/SimpleMDMpy/Apps.py
@@ -48,3 +48,9 @@ class Apps(SimpleMDMpy.SimpleMDM.Connection):
         url = self.url + "/" + app_id
         data = {}
         return self._delete_data(url, data) #pylint: disable=too-many-function-args
+
+    def list_installs(self, app_id):
+        """Returns a listing of the devices that an app is installed on."""
+        url = self.url + "/" + app_id
+        data = {}
+        return self._get_data(url, data)

--- a/SimpleMDMpy/SimpleMDM.py
+++ b/SimpleMDMpy/SimpleMDM.py
@@ -37,7 +37,11 @@ class Connection(object): #pylint: disable=old-style-class,too-few-public-method
                 raise ApiError(f"API returned status code {resp.status_code}")
             resp_json = resp.json()
             data = resp_json['data']
-            resp_data.extend(data)
+            if isinstance(data, list):
+                resp_data.extend(data)
+            else:
+                # Only one object may be returned instead of a list of objects
+                resp_data.append(data)
             has_more = resp_json.get('has_more', None)
             if has_more:
                 start_id = data[-1].get('id')


### PR DESCRIPTION
This adds the [List installs](https://api.simplemdm.com/#list-installs) and [List users](https://api.simplemdm.com/#list-users) endpoints according to the simpleMDM API.

Also fix an issue with responses that could be a single item instead of a list in some cases.